### PR TITLE
Plot onderdrukt bij monopoly opdrachten en hardcode en notallowed

### DIFF
--- a/tests/module3/monopolyTest.py
+++ b/tests/module3/monopolyTest.py
@@ -11,15 +11,15 @@ sys.path.append(parpath)
 
 from notAllowedCode import *
 
-#def before():
-#	import matplotlib.pyplot as plt
-#	plt.switch_backend("Agg")
-#	lib.neutralizeFunction(plt.pause)
+def before():
+	import matplotlib.pyplot as plt
+	plt.switch_backend("Agg")
+	lib.neutralizeFunction(plt.pause)
 
-#def after():
-#	import matplotlib.pyplot as plt
-#	plt.switch_backend("TkAgg")
-#	reload(plt)
+def after():
+	import matplotlib.pyplot as plt
+	plt.switch_backend("TkAgg")
+	reload(plt)
 
 @t.test(0)
 def hasworp_met_twee_dobbelstenen(test):

--- a/tests/module3/monopoly_realistischTest.py
+++ b/tests/module3/monopoly_realistischTest.py
@@ -12,15 +12,15 @@ sys.path.append(parpath)
 from notAllowedCode import *
 
 
-#def before():
-#	import matplotlib.pyplot as plt
-#	plt.switch_backend("Agg")
-#	lib.neutralizeFunction(plt.pause)
+def before():
+	import matplotlib.pyplot as plt
+	plt.switch_backend("Agg")
+	lib.neutralizeFunction(plt.pause)
 
-#def after():
-#	import matplotlib.pyplot as plt
-#	plt.switch_backend("TkAgg")
-#	reload(plt)
+def after():
+	import matplotlib.pyplot as plt
+	plt.switch_backend("TkAgg")
+	reload(plt)
 
 @t.test(0)
 def hassimuleer_groot_aantal_potjes_Monopoly(test):

--- a/tests/module4/autoritTest.py
+++ b/tests/module4/autoritTest.py
@@ -3,6 +3,14 @@ import checkpy.lib as lib
 import checkpy.assertlib as assertlib
 import importlib
 
+import os
+import sys
+
+parpath = os.path.abspath(os.path.join(os.path.realpath(__file__), os.pardir, os.pardir))
+sys.path.append(parpath)
+
+from notAllowedCode import *
+
 def sandbox():
 	lib.require("AutoRitData.csv", "http://www.nikhef.nl/~ivov/Python/SensorData/AutoRitData.csv")
 
@@ -27,6 +35,10 @@ def after():
 
 @t.test(0)
 def correctDistance(test):
+
+	notAllowed = {"sum": "sum(", "break": "break", "classes": "class"}
+	notAllowedCode(test, lib.source(_fileName), notAllowed)
+
 	def testMethod():
 		output = lib.outputOf(
 			test.fileName,

--- a/tests/module4/temperatuurTest.py
+++ b/tests/module4/temperatuurTest.py
@@ -5,6 +5,14 @@ import importlib
 import helpers
 import re
 
+import os
+import sys
+
+parpath = os.path.abspath(os.path.join(os.path.realpath(__file__), os.pardir, os.pardir))
+sys.path.append(parpath)
+
+from notAllowedCode import *
+
 def sandbox():
 	lib.require("DeBiltTempMax.txt", "http://www.nikhef.nl/~ivov/Python/KlimaatData/DeBiltTempMax.txt")
 	lib.require("DeBiltTempMin.txt", "http://www.nikhef.nl/~ivov/Python/KlimaatData/DeBiltTempMin.txt")
@@ -32,6 +40,10 @@ def after():
 
 @t.test(10)
 def correctHighestTemp(test):
+
+	notAllowed = {"sum": "sum(", "break": "break", "classes": "class"}
+	notAllowedCode(test, lib.source(_fileName), notAllowed)
+
 	def testMethod():
 		correctAnswer = "36.8"
 		if helpers.isHardcodedIn(correctAnswer, test.fileName):


### PR DESCRIPTION
Plot onderdrukt bij monopoly. Bij module 4 geen hardcoding, break, sum of classes toe gestaan. Als dat gebeurd komt er een melding, de uitkomst van de smiley wordt niet aangepast.